### PR TITLE
Modal popup & refactor component labeling system

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -92,5 +92,19 @@
       </div>
     </div>
     <script type="module" src="/main.ts"></script>
+
+    <dialog id="dialog">
+      <div class="backdrop"></div>
+      <div id="dialog-content"></div>
+
+      <hr>
+
+      <div class="dialog-action">
+        <button id="dialog-close-btn">
+          <i class="icon fa-solid fa-xmark"></i>
+          Close
+        </button>
+      </div>
+    </dialog>
   </body>
 </html>

--- a/src/pages/component/_template/labels/index.ts
+++ b/src/pages/component/_template/labels/index.ts
@@ -1,0 +1,1 @@
+export { default as LabelScopes } from "./scopes.svelte";

--- a/src/pages/component/_template/labels/info/amp.svelte
+++ b/src/pages/component/_template/labels/info/amp.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { LabelScopes } from "../";
+
+  const
+    {
+      componentData,
+    }: {
+      componentData: ComponentData,
+    } = $props()
+
+  , compName = componentData.nameDisplay ?? componentData.name
+  ;
+</script>
+
+<h2>AMP incompatible label</h2>
+
+<LabelScopes componentData={{
+  scopeAMPincompatible: true,
+}}/>
+
+<blockquote class="custom-callout">
+  <h3>Note</h3>
+  <p>
+    This only applies when you're using the component in devlog pages, and its only targetting mobile users.
+  </p>
+</blockquote>
+
+<p>
+  <b>{compName}</b> is incompatible with <a referrerpolicy="no-referrer" rel="nofollower noopener" href="https://en.wikipedia.org/wiki/Accelerated_Mobile_Pages" target="_blank">AMP</a> version of the devlog pages.
+</p>
+
+<p>
+  More on this <a referrerpolicy="no-referrer" rel="nofollower noopener" href="https://nnda.itch.io/pitch/devlog/1565390/rewrite-release-2-long-overdue-devlog" target="_blank">here</a>.
+</p>

--- a/src/pages/component/_template/labels/info/index.ts
+++ b/src/pages/component/_template/labels/info/index.ts
@@ -1,0 +1,2 @@
+export { default as InfoScopes } from "./scopes.svelte";
+export { default as InfoAMP } from "./amp.svelte";

--- a/src/pages/component/_template/labels/info/scopes.svelte
+++ b/src/pages/component/_template/labels/info/scopes.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+import { LabelScopes } from "../";
+
+  const
+    {
+      scopeStatus,
+      scopes,
+      componentData,
+    }: {
+      scopeStatus: ScopeStatus,
+      scopes: Scopes,
+      componentData: ComponentData,
+    } = $props()
+
+  , compName = componentData.nameDisplay ?? componentData.name
+  ;
+</script>
+
+<style lang="scss">
+  .scope-status {
+    text-transform: capitalize;
+  }
+
+  .scopes-list {
+    padding-left: 1em;
+    margin: 0;
+    /* display: inline-block; */
+  }
+
+</style>
+
+<h2>
+  <q class="scope-status">
+    {scopeStatus}
+  </q>
+  compatibility label
+</h2>
+
+<!-- TODO: -->
+<!-- dumb asf -->
+<LabelScopes previewOnly={true} componentData={(() => {
+  const
+    compData: Partial<ComponentData> = { "scopes": {} }
+  ;
+  // holy fuccc
+  (
+    compData.scopes as Record<ScopeStatus | string, Scopes>
+  )[scopeStatus] = scopes;
+
+  return compData;
+})()}/>
+
+<p>
+  <b>{compName}</b> is
+  {#if scopeStatus === "compatible"}
+    <b>fully compatible</b>
+  {:else if scopeStatus === "partial"}
+    <b>partially compatible</b>
+  {:else if scopeStatus === "none"}
+    <b>not compatible</b>
+  {:else if scopeStatus === "only"}
+    <b>only compatible</b>
+  {/if}
+  with the page(s) listed above.
+</p>
+
+<p>
+  {#if scopeStatus === "compatible"}
+  {:else if scopeStatus === "partial"}
+    The component will appears, or even behave differently on those pages.
+  {:else if scopeStatus === "none"}
+  {:else if scopeStatus === "only"}
+  {/if}
+</p>
+
+{#if componentData.compatibleOnInputs && scopeStatus !== "compatible"}
+  <hr>
+
+  <p>
+    Set these CSS variables manually, to make {compName} <b>compatible on all pages</b>:
+  </p>
+  <ul>
+    {#each componentData.compatibleOnInputs as input}
+      <li><code>--{input}</code></li>
+    {/each}
+  </ul>
+{/if}

--- a/src/pages/component/_template/labels/scopes.svelte
+++ b/src/pages/component/_template/labels/scopes.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import type { Component } from "svelte";
+
+  const
+    {
+      componentData,
+      previewOnly = false,
+    }: {
+      componentData: Partial<ComponentData>,
+      previewOnly?: boolean,
+    } = $props()
+
+  , itchScopes = [
+      "project",
+      "profile",
+      "jam",
+    ]
+
+  , scopesIcons: Record<ScopeStatus, string> = {
+      compatible: "fa-solid fa-circle-check",
+      partial: "fa-solid fa-triangle-exclamation",
+      none: "fa-solid fa-square-xmark",
+      only: "fa-solid fa-lock",
+    }
+  ;
+
+  import {
+    InfoAMP,
+    InfoScopes,
+  } from "./info/";
+  import { showModal } from "../../../../scripts/modal";
+</script>
+
+{#if componentData.scopes}
+  <ul class="labels-list scopes">
+    {#each Object.entries(componentData.scopes) as [scopeType, scopes]}
+
+      {@const scopeStatus: ScopeStatus = scopeType as ScopeStatus}
+      {@const scopeInfoComp = previewOnly ? null : () => {
+        showModal(
+          InfoScopes as Component,
+          // TODO: lack typing :/
+          {
+            "scopeStatus": scopeStatus,
+            "scopes": scopes,
+            "componentData": componentData,
+          },
+        );
+      }}
+
+      {#if typeof scopes === "string"}
+
+        <li class={scopeStatus}>
+          <button
+            onclick={scopeInfoComp}
+          >
+            <i class="icon {scopesIcons[scopeStatus]}"></i>
+            <ul>
+              <li class=text>
+                {scopes} pages
+                {#if scopeStatus === "only"}
+                  only
+                {/if}
+              </li>
+            </ul>
+          </button>
+        </li>
+
+      {:else}
+
+        <li class={scopeStatus}>
+          <button
+            onclick={scopeInfoComp}
+          >
+            <i class="icon {scopesIcons[scopeStatus]}"></i>
+            <ul>
+              {#each scopes as scope, n}
+                <li class="text {scopeStatus}">
+                  {scope} pages{#if n < scopes.length - 1},{/if}
+                </li>
+              {/each}
+            </ul>
+          </button>
+        </li>
+
+      {/if}
+
+    {/each}
+  </ul>
+{/if}
+
+{#if componentData.compatibleOnInputs}
+  <ul class="labels-list scopes compatible-all">
+    <li class="compatible">
+      <button
+        onclick={() => {
+          showModal(
+            InfoScopes as Component,
+            // TODO: lack typing :/
+            {
+              "scopeStatus": "compatible",
+              "scopes": itchScopes,
+              "componentData": componentData,
+            },
+          );
+        }}
+      >
+        <i class="icon {scopesIcons.compatible}"></i>
+        <ul>
+            {#each itchScopes as scope, n}
+              <li class="text compatible">
+                {scope} pages{#if n < itchScopes.length - 1},{/if}
+              </li>
+            {/each}
+        </ul>
+      </button>
+    </li>
+  </ul>
+{/if}
+
+{#if componentData.scopeAMPincompatible}
+  <ul class="labels-list">
+    <li class="none">
+      <button
+        class=""
+        onclick={previewOnly ? null : () => {
+          showModal(
+            InfoAMP as Component,
+            {
+              "componentData": componentData,
+            },
+          );
+        }}
+      >
+        <ul>
+          <li>
+            <i class="icon fa-solid fa-xmark"></i>
+            <!-- ain't bringing the whole Simple Icons library just yet -->
+            <svg
+              class="icon"
+              role="img"
+              fill="white"
+              style="width:1em;height:1em;"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg">
+                <title>AMP</title>
+                <path d="M12 0c6.628 0 12 5.373 12 12s-5.372 12-12 12C5.373 24 0 18.627 0 12S5.373 0 12 0zm-.92 19.278l5.034-8.377a.444.444 0 00.097-.268.455.455 0 00-.455-.455l-2.851.004.924-5.468-.927-.003-5.018 8.367s-.1.183-.1.291c0 .251.204.455.455.455l2.831-.004-.901 5.458z"/>
+              </svg>
+            AMP incompatible
+          </li>
+        </ul>
+      </button>
+    </li>
+  </ul>
+{/if}

--- a/src/pages/component/_template/page.svelte
+++ b/src/pages/component/_template/page.svelte
@@ -2,6 +2,10 @@
   import { onMount } from "svelte";
   import ComponentInput from "./input.svelte";
 
+  import {
+    LabelScopes,
+  } from "./labels/";
+
   const
     { children,
       data,
@@ -9,19 +13,6 @@
       children: any,
       data: ComponentData,
     } = $props()
-
-  , itchScopes = [
-      "project",
-      "profile",
-      "jam",
-    ]
-
-  , scopesIcons: Record<ScopeStatus, string> = {
-      compatible: "fa-solid fa-circle-check",
-      partial: "fa-solid fa-triangle-exclamation",
-      none: "fa-solid fa-square-xmark",
-      only: "fa-solid fa-lock",
-    }
 
   , tagsData: Record<ComponentTags, {icon: string, desc: string}> = {
       experimental: {
@@ -93,73 +84,7 @@
   data-comp-name={data.nameDisplay ?? data.name}
 >
   <div class="labels">
-
-    <ul class="labels-list scopes">
-      {#each Object.entries((data as ComponentData).scopes) as [scopeType, scopes]}
-
-        {@const scopeStatus: ScopeStatus = scopeType as ScopeStatus}
-
-        {#if typeof scopes === "string"}
-
-          <li class={scopeType}>
-            <i class="icon {scopesIcons[scopeStatus]}"></i>
-            <ul>
-              <li class=text>
-                {scopes} pages
-                {#if scopeType === "only"}
-                  only
-                {/if}
-              </li>
-            </ul>
-
-          </li>
-
-        {:else}
-
-          <li class={scopeType}>
-            <i class="icon {scopesIcons[scopeStatus]}"></i>
-            <ul>
-              {#each scopes as scope, n}
-                <li class="text {scopeType}">
-                  {scope} pages{#if n < scopes.length - 1},{/if}
-                </li>
-              {/each}
-            </ul>
-          </li>
-
-        {/if}
-
-      {/each}
-    </ul>
-
-    {#if data.compatibleOnInputs}
-
-      <ul class="labels-list scopes compatible-all">
-        <li class="compatible">
-          <i class="icon {scopesIcons.compatible}"></i>
-          <ul>
-            {#each itchScopes as scope, n}
-              <li class="text compatible">
-                {scope} pages{#if n < itchScopes.length - 1},{/if}
-              </li>
-            {/each}
-          </ul>
-        </li>
-      </ul>
-
-    {/if}
-
-    {#if data.scopeAMPincompatible}
-      <ul class="labels-list">
-        <li class="none">
-          <i class="icon fa-solid fa-xmark"></i>
-          <!-- ain't bringing the whole Simple Icons library just yet -->
-          <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>AMP</title><path d="M12 0c6.628 0 12 5.373 12 12s-5.372 12-12 12C5.373 24 0 18.627 0 12S5.373 0 12 0zm-.92 19.278l5.034-8.377a.444.444 0 00.097-.268.455.455 0 00-.455-.455l-2.851.004.924-5.468-.927-.003-5.018 8.367s-.1.183-.1.291c0 .251.204.455.455.455l2.831-.004-.901 5.458z"/></svg>
-          AMP incompatible
-        </li>
-      </ul>
-    {/if}
-
+    <LabelScopes componentData={data}/>
   </div>
 </div>
 

--- a/src/pages/component/_template/page.svelte
+++ b/src/pages/component/_template/page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  // import { CompatibilityNote } from "../_template/components";
   import ComponentInput from "./input.svelte";
 
   const
@@ -165,13 +164,3 @@
 </div>
 
 {@render children()}
-
-<!--
-{#if data.compatibleOnInputs}
-  <h2>
-    Compatibility Notes
-  </h2>
-
-  <CompatibilityNote inputs={data.compatibleOnInputs}/>
-{/if}
--->

--- a/src/scripts/modal.scss
+++ b/src/scripts/modal.scss
@@ -1,0 +1,47 @@
+@use "../styles/variables" as *;
+@use "sass:color";
+
+#dialog {
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  width: 65vw;
+
+  z-index: 9;
+
+  margin-top: 3em;
+  padding: 1em 1.5em;
+
+  background: $background-dark;
+  border: 1px solid $border-col;
+  box-sizing: border-box;
+  border-radius: 4px;
+
+  transition: .5s ease;
+  transition-behavior: allow-discrete;
+
+  &::backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+
+    background-color: rgba($background-dark, 50%);
+    backdrop-filter: blur(.8em);
+
+    opacity: 1;
+
+    transition: .5s ease;
+  }
+
+  @starting-style {
+    opacity: 0;
+    translate: 0 1em;
+
+    &::backdrop {
+      opacity: 0;
+    }
+  }
+}

--- a/src/scripts/modal.ts
+++ b/src/scripts/modal.ts
@@ -1,0 +1,35 @@
+import "./modal.scss";
+
+import {
+  mount,
+  type Component,
+} from "svelte";
+
+const
+  dlgEl = document.getElementById("dialog") as HTMLDialogElement
+, dlgContentEl = document.getElementById("dialog-content") as HTMLDialogElement
+, dlgCloseBtnEl = document.getElementById("dialog-close-btn") as HTMLDialogElement
+;
+
+export function showModal(
+  component: Component,
+  componentProps?: any,
+): void {
+
+  // TODO: when 'closing'(?) the dialog/modal via 'esc' keyboard,
+  // the content doesn't get cleared, and stacked :/
+  //
+  // is there like a 'close' event for <dialog> too???
+  dlgContentEl.innerHTML = "";
+
+  mount(component, {
+    target: dlgContentEl,
+    props: componentProps,
+  });
+  dlgEl.showModal();
+}
+
+dlgCloseBtnEl.addEventListener("click", () => {
+  dlgEl.close();
+  dlgContentEl.innerHTML = "";
+});

--- a/src/styles/_input.scss
+++ b/src/styles/_input.scss
@@ -119,11 +119,10 @@ input {
   }
 
   & > .icon {
-    font-size: .8em;
+    font-size: .85em;
   }
 
   &.no-style {
-    cursor: default;
     background: none;
 
     &:hover {

--- a/src/viewer/components/_scopes.scss
+++ b/src/viewer/components/_scopes.scss
@@ -12,16 +12,15 @@
   padding: 0;
   font-size: .9em;
 
-  & ul, li {
+  & ul, li, button {
     display: inline-flex;
     align-items: center;
     gap: .5em;
     padding: 0;
   }
 
-  & > li {
+  & button {
     margin: .2em .5em;
-    padding: .3em .5em;
     border-radius: 6px;
     // background: red;
 
@@ -39,18 +38,17 @@
 }
 
 @mixin style-scope-label($col) {
-  background: color.mix($background, $col, 70%);
+  & button {
+    background: color.mix($background, $col, 70%);
 
-  & > .icon {
-    color: lighten($col, 15%);
+    &:hover {
+      background: color.mix($background, $col, 55%);
+    }
+
+    & .icon {
+      color: lighten($col, 15%);
+    }
   }
-
-  // & .tooltip-content {
-  //   width: 100%;
-  //   padding: .5em;
-  //   background: color.mix($background, $col, 80%);
-  //   white-space: wrap;
-  // }
 }
 
 .compatible {


### PR DESCRIPTION
There's now this new modal system.

Component labels (compatibility & AMP label) on top of their pages will now show these snippets/docs when clicked:

<figure>
<img width="573" height="226" alt="" src="https://github.com/user-attachments/assets/855ac993-bf8b-4d7c-aa12-83d0f1931e80" />

<figcaption><br>
  Partial compatibility notice, on <b>Tooltip</b> component.
</figcaption>
</figure>

<br>
<br>

<figure>

<img width="573" height="348" alt="" src="https://github.com/user-attachments/assets/ba98fa56-1672-468e-b821-98a4748aceb4" />

<figcaption><br>
  AMP incompatibility notice, on <b>Tooltip</b> component.
</figcaption>
</figure>

<br>
<br>
